### PR TITLE
Fix menu sensitivity when using a gamepad

### DIFF
--- a/src/moon/ui/interfaces/moon-screen.cpp
+++ b/src/moon/ui/interfaces/moon-screen.cpp
@@ -99,7 +99,7 @@ void MoonScreen::Update(){
             widgets[i]->Update();
         }
         float yStick = GetStickValue(MoonButtons::U_STICK, false);
-        if(yStick > 0) {
+        if(yStick > 5) {
             if(stickExecuted) return;
             if(this->selected != NULL) return;
             this->widgets[this->scrollIndex]->selected = false;
@@ -109,7 +109,7 @@ void MoonScreen::Update(){
             this->widgets[this->scrollIndex]->selected = true;
             stickExecuted = true;
         }
-        if(yStick < 0) {
+        if(yStick < -5) {
             if(stickExecuted) return;
             if(this->selected != NULL) return;
             this->widgets[this->scrollIndex]->selected = false;

--- a/src/moon/ui/screens/achievements/achievements-view.cpp
+++ b/src/moon/ui/screens/achievements/achievements-view.cpp
@@ -64,12 +64,12 @@ void MoonAchievementsScreen::changeScroll(int idx){
 
 void MoonAchievementsScreen::Update(){
     float yStick = GetStickValue(MoonButtons::U_STICK, false);
-    if(yStick > 0) {
+    if(yStick > 5) {
         if(dispatched) return;
         MoonAchievementsScreen::changeScroll(-1);
         dispatched = true;
     }
-    if(yStick < 0) {
+    if(yStick < -5) {
         if(dispatched) return;
         MoonAchievementsScreen::changeScroll(1);
         dispatched = true;

--- a/src/moon/ui/screens/addons/addons-view.cpp
+++ b/src/moon/ui/screens/addons/addons-view.cpp
@@ -83,7 +83,7 @@ void MoonAddonsScreen::changeScroll(int idx){
 
 void MoonAddonsScreen::Update(){
     float yStick = GetStickValue(MoonButtons::U_STICK, false);
-    if(yStick > 0) {
+    if(yStick > 5) {
         if(dispatched) return;
         if(currentPack != NULL){
             if(currentSubItem > 0)
@@ -96,7 +96,7 @@ void MoonAddonsScreen::Update(){
         MoonAddonsScreen::changeScroll(-1);
         dispatched = true;
     }
-    if(yStick < 0) {
+    if(yStick < -5) {
         if(dispatched) return;
         if(currentPack != NULL){
             if(currentSubItem < 2)

--- a/src/moon/ui/screens/options/main-view.cpp
+++ b/src/moon/ui/screens/options/main-view.cpp
@@ -81,7 +81,7 @@ void MoonOptMain::Update(){
             isOpen = false;
         }
         float xStick = GetStickValue(MoonButtons::L_STICK, false);
-        if(xStick < 0) {
+        if(xStick < -50) {
             if(cswStickExecuted) return;
             if(categoryIndex > 0)
                 categoryIndex -= 1;
@@ -90,7 +90,7 @@ void MoonOptMain::Update(){
             this->setCategory(categoryIndex);
             cswStickExecuted = true;
         }
-        if(xStick > 0) {
+        if(xStick > 50) {
             if(cswStickExecuted) return;
             if(categoryIndex < categories.size() - 1)
                 categoryIndex += 1;

--- a/src/moon/ui/screens/store/store-view.cpp
+++ b/src/moon/ui/screens/store/store-view.cpp
@@ -80,7 +80,7 @@ void MoonStoreScreen::changeScroll(int idx){
 
 void MoonStoreScreen::Update(){
     float yStick = GetStickValue(MoonButtons::U_STICK, false);
-    if(yStick > 0) {
+    if(yStick > 5) {
         if(dispatched) return;
         if(currentPack != NULL){
             if(currentSubItem > 0)
@@ -93,7 +93,7 @@ void MoonStoreScreen::Update(){
         MoonStoreScreen::changeScroll(-1);
         dispatched = true;
     }
-    if(yStick < 0) {
+    if(yStick < -5) {
         if(dispatched) return;
         if(currentPack != NULL){
             if(currentSubItem < 2)


### PR DESCRIPTION
This pull request fixes the high menu sensitivity (accidental page switching) that seems to occur with controllers.